### PR TITLE
Change tx to wx in docker_calcNetworkIO as documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ async function dockerContainerData() {
 
 | Version        | Date           | Comment  |
 | -------------- | -------------- | -------- |
+| 1.4.4          | 2020-01-02     | Change `tx` to `wx` in `docker_calcNetworkIO` as documented|
 | 1.4.3          | 2020-12-03     | `typescript` definitions fix |
 | 1.4.2          | 2020-10-16     | `dockerContainers()` resolved hanging issue |
 | 1.4.1          | 2019-05-31     | `dockerInfo()` changed property naming style |

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -292,7 +292,7 @@ function docker_calcNetworkIO(networks) {
   }
   return {
     rx: rx,
-    tx: tx
+    wx: tx
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dockerstats",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Simple docker statistics libary",
   "license": "MIT",
   "author": "Sebastian Hildebrandt <hildebrandt@plus-innovations.com> (http://www.plus-innovations.com)",


### PR DESCRIPTION
## Pull Request

Fixes #7

#### Changes proposed:

* [x] Fix
* [ ] Add
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

In the object returned by `docker_calcNetworkIO`, `tx` has been renamed to `wx` to be in line with the documentation. 

