### PR TITLE
update the `sanitizeShellString` function to the same used in systeminformation

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -27,11 +27,12 @@ const stringToLower = new String().toLowerCase;
 const stringToString = new String().toString;
 const stringSubstr = new String().substr;
 const stringTrim = new String().trim;
+const mathMin = Math.min;
 
 function sanitizeShellString(str, strict = false) {
   const s = str || '';
   let result = '';
-  for (let i = 0; i <= 2000; i++) {
+  for (let i = 0; i <= mathMin(s.length, 2000); i++) {
     if (!(s[i] === undefined ||
       s[i] === '>' ||
       s[i] === '<' ||
@@ -54,9 +55,11 @@ function sanitizeShellString(str, strict = false) {
       s[i] === '\'' ||
       s[i] === '`' ||
       s[i] === '"' ||
-      strict && s[i] === ' ' ||
-      strict && s[i] == '{' ||
-      strict && s[i] == ')')) {
+      s[i].length > 1 ||
+      (strict && s[i] === '@') ||
+      (strict && s[i] === ' ') ||
+      (strict && s[i] == '{') ||
+      (strict && s[i] == ')'))) {
       result = result + s[i];
     }
   }


### PR DESCRIPTION
I was looking at CVE-2021-21315, and I noticed that this repo contains an outdated version of the `sanitizeShellString` function (compared to the one found in `systeminformation`).  

So I copy-pasted the implementation from `systeminformation`.  

This could help against type-confusion attacks. 